### PR TITLE
Fixes to A1 imports and include definitions from Induction.lagda.md

### DIFF
--- a/Exercises/CAS706/A1.lagda.md
+++ b/Exercises/CAS706/A1.lagda.md
@@ -8,7 +8,8 @@ import Relation.Binary.PropositionalEquality as Eq
 open Eq using (_≡_; refl; cong; sym)
 open Eq.≡-Reasoning using (begin_; step-≡-∣; step-≡-⟩; step-≡-⟨; _∎)
 
-open import CAS706.part1.Naturals -- everything
+open import Data.Nat using (ℕ; zero; suc; _+_; _*_; _∸_)
+open import Data.Nat.Properties using (+-assoc; +-identityʳ; +-suc; +-comm)
 ```
 
 Remember to add comments, in plain text before the code,
@@ -30,6 +31,13 @@ _ = refl
 ```
 
 == The exercises below are on the Bin type
+
+```agda
+data Bin : Set where
+  ⟨⟩ : Bin
+  _O : Bin → Bin
+  _I : Bin → Bin
+```
 
 Exercise: Increment (10 points)
 Define increment (add one).
@@ -92,41 +100,6 @@ _ = refl
 ```
 
 == Exercises below are back to proofs of facts about natural numbers
-
-The following theorems are copied over from `Induction.lagda.md`.
-The other option would be to import the file itself but it uses
-the standard library's built-in `ℕ` which clashes with
-the import of `CAS706.part1.Naturals`.
-
-```agda
-+-identityˡ : ∀ (m : ℕ) → zero + m ≡ m
-+-identityˡ m = refl
-
-+-identityʳ : ∀ (m : ℕ) → m + zero ≡ m
-+-identityʳ zero = refl
-+-identityʳ (suc m) = cong suc (+-identityʳ m)
-
-+-suc : ∀ (m n : ℕ) → m + suc n ≡ suc (m + n)
-+-suc zero n = refl
-+-suc (suc m) n = cong suc (+-suc m n)
-
-+-comm : ∀ (m n : ℕ) → m + n ≡ n + m
-+-comm zero n = sym (+-identityʳ n)
-+-comm (suc m) n = begin
-  suc (m + n) ≡⟨ cong suc (+-comm m n) ⟩
-  suc (n + m) ≡⟨ sym (+-suc n m) ⟩
-  n + suc m   ∎
-
-+-assoc : ∀ (m n p : ℕ) → (m + n) + p ≡ m + (n + p)
-+-assoc zero n p = refl
-+-assoc (suc m) n p = cong suc (+-assoc m n p)
-
-+-rearrange : ∀ (m n p q : ℕ) → (m + n) + (p + q) ≡ m + (n + p) + q
-+-rearrange m n p q = begin
-  (m + n) + (p + q)  ≡⟨ +-assoc (m + n) p q ⟨
-  ((m + n) + p) + q  ≡⟨ cong (_+ q) (+-assoc m n p) ⟩ 
-  m + (n + p) + q    ∎
-```
 
 Exercise: AddSwap (10 point)
 Please do this without using induction/recursion.

--- a/Exercises/CAS706/A1.lagda.md
+++ b/Exercises/CAS706/A1.lagda.md
@@ -5,8 +5,8 @@ from the CS747 course at Waterloo.
 module CAS706.A1 where
 
 import Relation.Binary.PropositionalEquality as Eq
-open Eq using (_≡_; refl)
-open Eq.≡-Reasoning using (begin_; step-≡-∣; step-≡-⟨; _∎)
+open Eq using (_≡_; refl; cong; sym)
+open Eq.≡-Reasoning using (begin_; step-≡-∣; step-≡-⟩; step-≡-⟨; _∎)
 
 open import CAS706.part1.Naturals -- everything
 ```
@@ -92,6 +92,41 @@ _ = refl
 ```
 
 == Exercises below are back to proofs of facts about natural numbers
+
+The following theorems are copied over from `Induction.lagda.md`.
+The other option would be to import the file itself but it uses
+the standard library's built-in `ℕ` which clashes with
+the import of `CAS706.part1.Naturals`.
+
+```agda
++-identityˡ : ∀ (m : ℕ) → zero + m ≡ m
++-identityˡ m = refl
+
++-identityʳ : ∀ (m : ℕ) → m + zero ≡ m
++-identityʳ zero = refl
++-identityʳ (suc m) = cong suc (+-identityʳ m)
+
++-suc : ∀ (m n : ℕ) → m + suc n ≡ suc (m + n)
++-suc zero n = refl
++-suc (suc m) n = cong suc (+-suc m n)
+
++-comm : ∀ (m n : ℕ) → m + n ≡ n + m
++-comm zero n = sym (+-identityʳ n)
++-comm (suc m) n = begin
+  suc (m + n) ≡⟨ cong suc (+-comm m n) ⟩
+  suc (n + m) ≡⟨ sym (+-suc n m) ⟩
+  n + suc m   ∎
+
++-assoc : ∀ (m n p : ℕ) → (m + n) + p ≡ m + (n + p)
++-assoc zero n p = refl
++-assoc (suc m) n p = cong suc (+-assoc m n p)
+
++-rearrange : ∀ (m n p q : ℕ) → (m + n) + (p + q) ≡ m + (n + p) + q
++-rearrange m n p q = begin
+  (m + n) + (p + q)  ≡⟨ +-assoc (m + n) p q ⟨
+  ((m + n) + p) + q  ≡⟨ cong (_+ q) (+-assoc m n p) ⟩ 
+  m + (n + p) + q    ∎
+```
 
 Exercise: AddSwap (10 point)
 Please do this without using induction/recursion.


### PR DESCRIPTION
In addition to adding to the import lists, I've also copied theorems over from `Induction.lagda.md` into the assignment. Importing it directly causes an issue with the different usage of the built-in ℕ type.